### PR TITLE
Raffle rework

### DIFF
--- a/src/interfaces/IBBitsRaffle.sol
+++ b/src/interfaces/IBBitsRaffle.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.25;
 interface IBBitsRaffle {
     enum RaffleStatus {
         PendingRaffle,
-        InRaffle,
-        PendingSettlement
+        InRaffle
     }
 
     struct Raffle {
@@ -29,13 +28,11 @@ interface IBBitsRaffle {
     error RaffleOnGoing();
     error AlreadyEnteredRaffle();
     error MustPayAntiBotFee();
-    error SeedMustBeReset();
     error TransferFailed();
     error IndexOutOfBounds();
 
     event BasedBitsDeposited(address _sponsor, uint256 _tokenId);
     event NewRaffleStarted(uint256 _raffleId);
     event RaffleEntered(uint256 _raffleId, address _user);
-    event RandomSeedSet(uint256 _raffleId, uint256 _seed);
     event RaffleSettled(uint256 _raffleId, address _winner, uint256 _tokenId);
 }

--- a/test/utils/BBitsTestUtils.sol
+++ b/test/utils/BBitsTestUtils.sol
@@ -141,21 +141,6 @@ contract BBitsTestUtils is Test, IERC721Receiver {
 
             /// Start next raffle
             raffle.startNextRaffle();
-        } else if (_status == IBBitsRaffle.RaffleStatus.PendingSettlement) {
-            /// Deposit three tokenIds
-            uint256[] memory tokenIds = new uint256[](3);
-            tokenIds[0] = ownerTokenIds[0];
-            tokenIds[1] = ownerTokenIds[1];
-            tokenIds[2] = ownerTokenIds[2];
-            raffle.depositBasedBits(tokenIds);
-
-            /// Start next raffle
-            raffle.startNextRaffle();
-
-            /// Set Random Seed
-            vm.warp(block.timestamp + 1.01 days);
-            uint256 antiBotFee = raffle.antiBotFee();
-            raffle.setRandomSeed{value: antiBotFee}();
         } else {
             /// @dev For Pending Raffle status get to just after settled
             /// Deposit three tokenIds
@@ -168,12 +153,8 @@ contract BBitsTestUtils is Test, IERC721Receiver {
             /// Start next raffle
             raffle.startNextRaffle();
 
-            /// Set random seed
-            vm.warp(block.timestamp + 1.01 days);
-            uint256 antiBotFee = raffle.antiBotFee();
-            raffle.setRandomSeed{value: antiBotFee}();
-
             /// Settle raffle
+            vm.warp(block.timestamp + 1.01 days);
             vm.roll(block.number + 2);
             raffle.settleRaffle();
         }


### PR DESCRIPTION
Changes:

- Eligibility for free entry: 48 hour since recent checkin, and no limit on total number of free entries.
- Removed seed setting functionality, pseudo-randomness is now generated when raffle is settled.
- New raffle is automatically initiated during settlement if there is an available prize.
- BBs can be returned at any stage if the contract is paused.
