### PR TITLE
Access control added

### DIFF
--- a/test/BBMintRaffleNFT.t.sol
+++ b/test/BBMintRaffleNFT.t.sol
@@ -459,7 +459,7 @@ contract BBMintRaffleNFTTest is BBitsTestUtils, IBBMintRaffleNFT {
     }
 
     function testSetDescription() public prank(owner) {
-        assertEq(mintRaffle.description(), "!!! ADD IN DESCRIPTION HERE !!!");
+        assertEq(mintRaffle.description(), "Bit98 is a fully on-chain pixel art collection by filter8.eth. Inspired by the color aesthetics of Windows 98, the collection features a novel minting and gamification mechanism, with a new Bit98 generated every 4 hours. At the end of the minting period, a single-edition NFT will be raffled off to one of the minters. Only 512 Bit98s will ever exist! Mint at https://www.basedbits.fun");
         bytes memory newDescription = "ARTY ART";
         mintRaffle.setDescription(newDescription);
         assertEq(mintRaffle.description(), newDescription);

--- a/test/utils/BBitsTestUtils.sol
+++ b/test/utils/BBitsTestUtils.sol
@@ -116,7 +116,7 @@ contract BBitsTestUtils is Test, IERC721Receiver, IERC1155Receiver {
 
         owner = 0x1d671d1B191323A38490972D58354971E5c1cd2A;
         /// @dev Use this to access owner token Ids to allow for easy test updating
-        ownerTokenIds = [275, 2352, 2648, 6845, 5537];
+        ownerTokenIds = [6311, 5222, 5219, 4770, 3121];
     }
 
     /// ON RECEIVED ///


### PR DESCRIPTION
- Removed Ownable and replaced with Access Control
#### Two Roles
- **Default Admin Role**: controls settlement, starting a new round, pause, set duration, rewards per round, reward percentage, and which addresses are granted admin roles
- **Admin Role**: controls post approvals every round

Multiple addresses can be granted to either roles