### PR TITLE
Add max mint limit for PotRaider

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -67,6 +67,7 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
     uint256 public lotteryParticipationDays = 365;
     uint256 public constant LOTTERY_TICKET_PRICE_USD = 1; // $1 per ticket
     uint256 public constant USDC_DECIMALS = 6; // USDC has 6 decimals
+    uint256 public constant MAX_MINT_PER_CALL = 50; // Max NFTs mintable per call
     address public lotteryContract;
     address public usdcContract;
     address public uniswapRouter; // Uniswap V3 Router for ETH→USDC swaps
@@ -117,6 +118,7 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
     error NoTreasuryAvailable();
     error ExchangeTransferFailed();
     error WETHNotConfigured();
+    error MaxMintPerCallExceeded();
     function _checkWETHConfigured() private view {
         if (wethAddress == address(0)) {
             revert WETHNotConfigured();
@@ -141,6 +143,9 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
     function mint(uint256 quantity) external payable whenNotPaused {
         if (quantity == 0) {
             revert QuantityZero();
+        }
+        if (quantity > MAX_MINT_PER_CALL) {
+            revert MaxMintPerCallExceeded();
         }
         if (msg.value < mintPrice * quantity) {
             revert InsufficientPayment();

--- a/test/PotRaider.t.sol
+++ b/test/PotRaider.t.sol
@@ -66,18 +66,18 @@ contract PotRaiderTest is Test {
     }
 
     function testMintMaxQuantity() public {
+        uint256 maxQuantity = potRaider.MAX_MINT_PER_CALL();
         vm.prank(user1);
-        potRaider.mint{value: mintPrice * 10}(10);
-        assertEq(potRaider.totalSupply(), 10);
-        assertEq(potRaider.circulatingSupply(), 10);
+        potRaider.mint{value: mintPrice * maxQuantity}(maxQuantity);
+        assertEq(potRaider.totalSupply(), maxQuantity);
+        assertEq(potRaider.circulatingSupply(), maxQuantity);
     }
 
     function testMintLargeQuantity() public {
-        uint256 largeQuantity = 100;
+        uint256 largeQuantity = potRaider.MAX_MINT_PER_CALL() + 1;
         vm.prank(user1);
+        vm.expectRevert(PotRaider.MaxMintPerCallExceeded.selector);
         potRaider.mint{value: mintPrice * largeQuantity}(largeQuantity);
-        assertEq(potRaider.totalSupply(), largeQuantity);
-        assertEq(potRaider.circulatingSupply(), largeQuantity);
     }
 
     function testMintInsufficientPayment() public {


### PR DESCRIPTION
## Summary
- enforce max mint per call in `PotRaider`
- update tests to reflect new restriction

## Testing
- `forge build --contracts src/PotRaider.sol` *(fails: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_687eedf3f82c8332a581399891bd8d37