### PR TITLE
Fix slippage calc for Uniswap swap

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -532,6 +532,7 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
         }
         _checkWETHConfigured();
         // Create swap parameters
+        uint256 estimatedUSDC = _estimateUSDCForETH(ethAmount);
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
             tokenIn: wethAddress, // Use WETH address instead of address(0)
             tokenOut: usdcContract,
@@ -539,7 +540,7 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
             recipient: address(this),
             deadline: block.timestamp + 300, // 5 minutes
             amountIn: ethAmount,
-            amountOutMinimum: (ethAmount * 95) / 100, // 5% slippage protection
+            amountOutMinimum: (estimatedUSDC * 95) / 100, // 5% slippage protection
             sqrtPriceLimitX96: 0
         });
 

--- a/test/PotRaider.t.sol
+++ b/test/PotRaider.t.sol
@@ -569,6 +569,8 @@ contract PotRaiderTest is Test {
         assertEq(mockRouter.receivedETH(), dailyAmount, "Incorrect ETH sent");
         assertEq(mockLottery.purchaseValue(), expectedUSDC, "Incorrect USDC value");
         assertEq(mockLottery.purchaseRecipient(), address(potRaider));
+        (,,,,,,uint256 amountOutMinimum,) = mockRouter.lastParams();
+        assertEq(amountOutMinimum, (expectedUSDC * 95) / 100, "Incorrect slippage amount");
         assertEq(potRaider.lotteryPurchasedForDay(0), dailyAmount);
     }
 


### PR DESCRIPTION
## Summary
- calculate expected USDC with `_estimateUSDCForETH`
- set swap slippage using that estimate
- test router slippage param via MockSwapRouter

## Testing
- `CI=true forge test --match-contract PotRaiderTest -vvv`

------
https://chatgpt.com/codex/tasks/task_e_687eedf3f57c83329c35516ddceb5981