### PR TITLE
Remove unused WithdrawFailed error

### DIFF
--- a/src/AEYE.sol
+++ b/src/AEYE.sol
@@ -96,7 +96,6 @@ contract AEYE is
 
     error MustPayMintPrice();
     error MetadataNotSet();
-    error WithdrawFailed();
     error InvalidPercentage();
     error TransferFailed();
     error NoRewardsToClaim();


### PR DESCRIPTION
## Summary
- drop unused `WithdrawFailed` error from AEYE
- leave other declarations untouched

## Testing
- `forge build` *(fails: process did not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687ef97bf1c88332ac2b3ed06c0504a2