### PR TITLE
Fix PotRaider deployment script

### DIFF
--- a/script/potraider/PotRaiderDeploy.s.sol
+++ b/script/potraider/PotRaiderDeploy.s.sol
@@ -11,6 +11,8 @@ contract PotRaiderDeploy is Script {
     address public artist = 0x1d671d1B191323A38490972D58354971E5c1cd2A;
     address public usdc = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913; // USDC on Base
     address public uniswapRouter = 0x2626664c2603336E57B271c5C0b26F421741e481; // Uniswap V3 Router on Base
+    address public uniswapQuoter = 0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a; // Uniswap V3 QuoterV2 on Base
+    address public weth = 0x4200000000000000000000000000000000000006; // WETH on Base
 
     function run() external {
         vm.startBroadcast();
@@ -24,8 +26,13 @@ contract PotRaiderDeploy is Script {
         // Set the USDC contract address
         potRaider.setUSDCContract(usdc);
         
-        // Set the Uniswap router address
+        // Configure Uniswap so lottery purchases don't revert
+        // If the quoter is unset the contract throws `UniswapQuoterNotConfigured`
         potRaider.setUniswapRouter(uniswapRouter);
+        potRaider.setUniswapQuoter(uniswapQuoter);
+
+        // Configure WETH for swaps (required or `_checkWETHConfigured` reverts)
+        potRaider.setWETHAddress(weth);
 
         // Set the creator and burn percentages (10% each)
         potRaider.setPercentages(1000, 1000);


### PR DESCRIPTION
## Summary
- configure Uniswap quoter and WETH addresses when deploying PotRaider
- clarify comments explaining these addresses are required

## Testing
- `forge build` *(failed: Compiling 145 files with Solc 0.8.25)*

------
https://chatgpt.com/codex/tasks/task_e_68804d24ec6c8332ae9cde69b11507fc