### PR TITLE
Fix PotRaider burn logic and update tests

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -36,6 +36,10 @@ interface ILotteryContract {
     function roundDurationInSeconds() external view returns (uint256);
 }
 
+interface Burner {
+    function burn(uint256 _minAmountBurned) external payable;
+}
+
 contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -100,7 +104,6 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
     error QuoterCallFailed();
     error QuantityZero();
     error InsufficientPayment();
-    error BurnTransferFailed();
     error ArtistTransferFailed();
     error NotOwner();
     error NoNFTsInCirculation();
@@ -146,10 +149,7 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
 
         // Send burn amount to burner contract
         if (burnAmount > 0) {
-            (bool burnSuccess,) = burnerContract.call{value: burnAmount}("");
-            if (!burnSuccess) {
-                revert BurnTransferFailed();
-            }
+            Burner(burnerContract).burn{value: burnAmount}(0);
         }
 
         // Send artist amount to artist

--- a/src/PotRaiderTest.sol
+++ b/src/PotRaiderTest.sol
@@ -36,6 +36,10 @@ interface ILotteryContract {
     function roundDurationInSeconds() external view returns (uint256);
 }
 
+interface Burner {
+    function burn(uint256 _minAmountBurned) external payable;
+}
+
 contract PotRaiderTest is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
@@ -100,7 +104,6 @@ contract PotRaiderTest is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyG
     error QuoterCallFailed();
     error QuantityZero();
     error InsufficientPayment();
-    error BurnTransferFailed();
     error ArtistTransferFailed();
     error NotOwner();
     error NoNFTsInCirculation();
@@ -146,10 +149,7 @@ contract PotRaiderTest is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyG
 
         // Send burn amount to burner contract
         if (burnAmount > 0) {
-            (bool burnSuccess,) = burnerContract.call{value: burnAmount}("");
-            if (!burnSuccess) {
-                revert BurnTransferFailed();
-            }
+            Burner(burnerContract).burn{value: burnAmount}(0);
         }
 
         // Send artist amount to artist

--- a/test/mocks/MockBurner.sol
+++ b/test/mocks/MockBurner.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+interface Burner {
+    function burn(uint256 _minAmountBurned) external payable;
+}
+
+contract MockBurner is Burner {
+    receive() external payable {}
+    function burn(uint256) external payable {}
+}

--- a/test/mocks/ReentrantMint.sol
+++ b/test/mocks/ReentrantMint.sol
@@ -3,7 +3,11 @@ pragma solidity 0.8.25;
 
 import {PotRaider} from "@src/PotRaider.sol";
 
-contract ReentrantMint {
+interface Burner {
+    function burn(uint256 _minAmountBurned) external payable;
+}
+
+contract ReentrantMint is Burner {
     PotRaider public potRaider;
     bool public reentered;
 
@@ -13,6 +17,13 @@ contract ReentrantMint {
 
     function attack() external payable {
         potRaider.mint{value: msg.value}(1);
+    }
+
+    function burn(uint256) external payable {
+        if (!reentered) {
+            reentered = true;
+            potRaider.mint{value: potRaider.mintPrice()}(1);
+        }
     }
 
     receive() external payable {


### PR DESCRIPTION
## Summary
- make PotRaider use Burner interface like AEYE
- update PotRaiderTest version too
- adjust reentrancy mock and unit tests
- add reusable MockBurner for tests

## Testing
- `forge test --match-test testMintReentrancy -vvvv`
- `forge test --match-path test/PotRaider.t.sol --match-test testMint -vv`
- `forge test --match-path test/PotRaider.t.sol -vv`
- `forge test --match-path test/AEYE.t.sol --match-test test_InitialState -vv`


------
https://chatgpt.com/codex/tasks/task_e_6883e866d56c8332b08dcdb9b0a5ef20