### PR TITLE
Add setArtistPercentage setter with tests

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -253,6 +253,15 @@ contract PotRaider is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyGuard
         burnPercentage = _burnPercentage;
     }
 
+    /// @notice Set the artist percentage for mint fees
+    /// @param _artistPercentage New artist percentage (10_000 = 100%)
+    function setArtistPercentage(uint256 _artistPercentage) external onlyOwner {
+        require(_artistPercentage <= 10_000, "Artist percentage cannot exceed 100%");
+        require(_artistPercentage + burnPercentage <= 10_000, "Total percentages cannot exceed 100%");
+        artistPercentage = uint16(_artistPercentage);
+        emit PercentagesUpdated(burnPercentage, _artistPercentage);
+    }
+
     /// @notice Update the burn and artist percentages
     /// @param _burnPercentage New burn percentage (10_000 = 100%)
     /// @param _artistPercentage New artist percentage (10_000 = 100%)

--- a/test/PotRaider.t.sol
+++ b/test/PotRaider.t.sol
@@ -345,6 +345,28 @@ contract PotRaiderTest is Test {
         potRaider.setBurnPercentage(10001);
     }
 
+    function testSetArtistPercentage() public {
+        uint256 newPercentage = 1500; // 15%
+        potRaider.setArtistPercentage(newPercentage);
+        assertEq(potRaider.artistPercentage(), newPercentage);
+    }
+
+    function testSetArtistPercentageOnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        potRaider.setArtistPercentage(1500);
+    }
+
+    function testSetArtistPercentageExceeds100() public {
+        vm.expectRevert("Artist percentage cannot exceed 100%");
+        potRaider.setArtistPercentage(10001);
+    }
+
+    function testSetArtistPercentageTotalExceeds100() public {
+        vm.expectRevert("Total percentages cannot exceed 100%");
+        potRaider.setArtistPercentage(9001);
+    }
+
     function testSetPercentages() public {
         uint256 newBurnPercentage = 500; // 5% (500 basis points)
         uint256 newArtistPercentage = 2000; // 20% (2000 basis points)
@@ -584,9 +606,7 @@ contract PotRaiderTest is Test {
 
         uint256 usdcAmount = 1_000_000;
         vm.mockCall(
-            usdcContract,
-            abi.encodeWithSelector(IERC20.balanceOf.selector, address(potRaider)),
-            abi.encode(usdcAmount)
+            usdcContract, abi.encodeWithSelector(IERC20.balanceOf.selector, address(potRaider)), abi.encode(usdcAmount)
         );
 
         uint256[2] memory values = potRaider.getRedeemValue(0);


### PR DESCRIPTION
## Summary
- add `setArtistPercentage` setter with `onlyOwner` in `PotRaider.sol`
- ensure new artist percentage doesn't exceed limits and emit event
- extend test suite with success and failure tests for the setter

## Testing
- `forge test --match-contract PotRaiderTest -vvv` *(fails: environment timed out compiling)*

------
https://chatgpt.com/codex/tasks/task_e_6882535e46ec8332bc0ae12f42834f22