### PR TITLE
Remove redundant USDC estimate

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -159,9 +159,6 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
         uint256 dailyAmount = getDailyPurchaseAmount();
         if (dailyAmount == 0) revert InsufficientTreasury();
 
-        // Estimate USDC output using Uniswap V3 Quoter
-        uint256 estimatedUSDC = _estimateUSDCForETH(dailyAmount);
-        if (estimatedUSDC < lotteryTicketPriceUSD) revert InsufficientUSDCForTicket();
 
         // Update ETH amount spent on daily lottery tickets
         lotteryPurchasedForDay[currentLotteryRound] = dailyAmount;

--- a/src/PotRaiderTest.sol
+++ b/src/PotRaiderTest.sol
@@ -440,13 +440,6 @@ contract PotRaiderTest is ERC721, ERC721Burnable, Ownable, Pausable, ReentrancyG
             revert InsufficientTreasury();
         }
 
-        // Estimate USDC output using Uniswap V3 Quoter
-        uint256 estimatedUSDC = _estimateUSDCForETH(dailyAmount);
-        uint256 ticketPriceUSDC = LOTTERY_TICKET_PRICE_USD * (10 ** USDC_DECIMALS);
-        if (estimatedUSDC < ticketPriceUSDC) {
-            revert InsufficientUSDCForTicket();
-        }
-
         // Update state first (before external calls)
         lotteryPurchasedForDay[currentLotteryRound] = dailyAmount;
 


### PR DESCRIPTION
## Summary
- remove `_estimateUSDCForETH` pre‑check from `purchaseLotteryTicket`
- update the test helper contract accordingly

## Testing
- `forge build` *(fails: process never finished)*

------
https://chatgpt.com/codex/tasks/task_e_6888318a63d88332bb799e4c9acd5446