### PR TITLE
Track USDC amount and timestamp for PotRaider lottery purchases

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -62,7 +62,12 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
     /// @dev Internal counter to track number of lotteries entered.
     uint256 public currentLotteryRound;
 
-    mapping(uint256 => uint256) public lotteryPurchasedForDay;
+    struct LotteryPurchase {
+        uint256 usdcAmount;
+        uint256 timestamp;
+    }
+
+    mapping(uint256 => LotteryPurchase) public lotteryPurchasedForDay;
 
     constructor(
         address _owner,
@@ -160,11 +165,14 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
         if (dailyAmount == 0) revert InsufficientTreasury();
 
 
-        // Update ETH amount spent on daily lottery tickets
-        lotteryPurchasedForDay[currentLotteryRound] = dailyAmount;
-
         // Swap ETH to USDC using Uniswap V3
         uint256 usdcAmount = _swapETHForUSDC(dailyAmount);
+
+        // Record lottery purchase information in USDC and timestamp
+        lotteryPurchasedForDay[currentLotteryRound] = LotteryPurchase({
+            usdcAmount: usdcAmount,
+            timestamp: block.timestamp
+        });
 
         // Purchase lottery tickets using the lottery contract's purchaseTickets method
         lottery.purchaseTickets(lotteryReferrer, usdcAmount, address(this));


### PR DESCRIPTION
## Summary
- keep lottery purchase info in USDC instead of ETH
- record timestamp of each purchase

## Testing
- `forge build` *(fails: Compiling 148 files with Solc 0.8.25)*

------
https://chatgpt.com/codex/tasks/task_e_688836655d5c8332b66df38166ff6750