### PR TITLE
Track lottery tickets instead of USDC

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -58,11 +58,11 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
     uint256 public currentLotteryDay;
 
     struct LotteryPurchase {
-        uint256 usdcAmount;
+        uint256 tickets;
         uint256 timestamp;
     }
 
-    mapping(uint256 => LotteryPurchase) public lotteryPurchasedForDay;
+    mapping(uint256 => LotteryPurchase) public lotteryPurchaseHistory;
 
     constructor(
         address _owner,
@@ -153,14 +153,19 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
         // Swap ETH to USDC using Uniswap V3
         uint256 usdcAmount = _swapETHForUSDC(dailyAmount);
 
-        // Record lottery purchase information in USDC and timestamp
-        lotteryPurchasedForDay[currentLotteryDay] = LotteryPurchase({
-            usdcAmount: usdcAmount,
+        // Calculate number of whole tickets purchased
+        uint256 tickets = usdcAmount / lotteryTicketPriceUSD;
+        if (tickets == 0) revert InsufficientUSDCForTicket();
+
+        // Record lottery purchase information in tickets and timestamp
+        lotteryPurchaseHistory[currentLotteryDay] = LotteryPurchase({
+            tickets: tickets,
             timestamp: block.timestamp
         });
 
-        // Purchase lottery tickets using the lottery contract's purchaseTickets method
-        lottery.purchaseTickets(lotteryReferrer, usdcAmount, address(this));
+        // Purchase only the number of full tickets
+        uint256 spendAmount = tickets * lotteryTicketPriceUSD;
+        lottery.purchaseTickets(lotteryReferrer, spendAmount, address(this));
 
         // Update lottery counter
         currentLotteryDay++;

--- a/test/PotRaider.t.sol
+++ b/test/PotRaider.t.sol
@@ -309,6 +309,12 @@ contract PotRaiderTest is BBitsTestUtils {
     function testMintAndPurchase() public prank(user0) {
         potRaider.mint{value: 50 * mintPrice}(50);
         potRaider.mint{value: 50 * mintPrice}(50);
+        // Ensure the contract has enough ETH to buy at least one ticket
+        vm.deal(address(potRaider), 1 ether);
+
         potRaider.purchaseLotteryTicket();
+
+        (uint256 tickets,) = potRaider.lotteryPurchaseHistory(0);
+        assertGt(tickets, 0);
     }
 }


### PR DESCRIPTION
## Summary
- rename `lotteryPurchasedForDay` to `lotteryPurchaseHistory`
- store and calculate ticket counts instead of raw USDC
- only save and spend whole ticket counts

## Testing
- `forge test --match-contract PotRaiderTest` *(fails: process did not complete after compiling due to missing network configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6890e77ff4cc83329cbab5552d6c38b1