### PR TITLE
Cap PotRaider NFT supply at 1000

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -35,6 +35,8 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
 
     uint256 public immutable maxMint;
 
+    uint256 public constant MAX_SUPPLY = 1000;
+
     uint256 public totalSupply;
 
     uint256 public circulatingSupply;
@@ -97,6 +99,7 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
     function mint(uint256 quantity) external payable whenNotPaused nonReentrant {
         if (quantity == 0) revert QuantityZero();
         if (quantity > maxMint) revert MaxMintPerCallExceeded();
+        if (totalSupply + quantity > MAX_SUPPLY) revert MaxSupplyReached();
         if (msg.value < mintPrice * quantity) revert InsufficientPayment();
 
         uint256 burnAmount = (msg.value * burnPercentage) / 10_000;

--- a/src/interfaces/IPotRaider.sol
+++ b/src/interfaces/IPotRaider.sol
@@ -11,6 +11,7 @@ interface IPotRaider {
 
     error QuantityZero();
     error MaxMintPerCallExceeded();
+    error MaxSupplyReached();
     error InsufficientPayment();
     error TransferFailed();
     error InvalidPercentage();


### PR DESCRIPTION
## Summary
- Add MAX_SUPPLY constant and enforce 1000 token cap in PotRaider
- Expose MaxSupplyReached error via IPotRaider
- Test supply cap and update constructor expectations

## Testing
- `forge test`


------
https://chatgpt.com/codex/tasks/task_e_689512676cf883329568044803f9513b