### PR TITLE
Swap leftover USDC only in $5 chunks

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -37,6 +37,8 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
 
     uint256 public constant MAX_SUPPLY = 1000;
 
+    uint256 constant CHUNK_USDC = 5e6;
+
     uint256 public totalSupply;
 
     uint256 public circulatingSupply;
@@ -166,10 +168,10 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
         uint256 spendAmount = tickets * lotteryTicketPriceUSD;
         lottery.purchaseTickets(lotteryReferrer, spendAmount, address(this));
 
-        // Swap any leftover USDC back to ETH
-        uint256 leftoverUSDC = usdc.balanceOf(address(this));
-        if (leftoverUSDC > 0) {
-            _swapUSDCforETH(leftoverUSDC);
+        // Swap leftover USDC to ETH in 5 USDC increments
+        uint256 usdcBalance = usdc.balanceOf(address(this));
+        if (usdcBalance >= CHUNK_USDC) {
+            _swapUSDCforETH(CHUNK_USDC);
         }
 
         // Update lottery counter


### PR DESCRIPTION
## Summary
- add `CHUNK_USDC` constant for 5 USDC increments
- swap leftover USDC to ETH only when balance exceeds 5 USDC

## Testing
- `forge test` *(fails: compilation did not complete, process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6897accf4d548332bb02fd4015071c1e