### PR TITLE
Increment lottery day before recording purchases

### DIFF
--- a/src/PotRaider.sol
+++ b/src/PotRaider.sol
@@ -161,8 +161,12 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
         uint256 tickets = usdcAmount / lotteryTicketPriceUSD;
         if (tickets == 0) revert InsufficientUSDCForTicket();
 
+        // Update lottery counter before recording purchase
+        currentLotteryDay++;
+
         // Record lottery purchase information in tickets and timestamp
-        lotteryPurchaseHistory[currentLotteryDay] = LotteryPurchase({tickets: tickets, timestamp: block.timestamp});
+        lotteryPurchaseHistory[currentLotteryDay] =
+            LotteryPurchase({tickets: tickets, timestamp: block.timestamp});
 
         // Purchase only the number of full tickets
         uint256 spendAmount = tickets * lotteryTicketPriceUSD;
@@ -174,8 +178,6 @@ contract PotRaider is IPotRaider, ERC721Burnable, Ownable, Pausable, ReentrancyG
             _swapUSDCforETH(CHUNK_USDC);
         }
 
-        // Update lottery counter
-        currentLotteryDay++;
         emit LotteryTicketPurchased(currentLotteryDay, dailyAmount);
     }
 

--- a/test/PotRaider.t.sol
+++ b/test/PotRaider.t.sol
@@ -348,7 +348,8 @@ contract PotRaiderTest is BBitsTestUtils {
 
         potRaider.purchaseLotteryTicket();
 
-        (uint256 tickets,) = potRaider.lotteryPurchaseHistory(0);
+        (uint256 tickets,) = potRaider.lotteryPurchaseHistory(1);
         assertGt(tickets, 0);
+        assertEq(potRaider.currentLotteryDay(), 1);
     }
 }


### PR DESCRIPTION
## Summary
- increment `currentLotteryDay` before recording history and purchasing tickets
- ensure lottery purchases and events use the updated day
- adjust tests to expect first purchase under day 1

## Testing
- `forge test --match-contract PotRaiderTest -vvv`


------
https://chatgpt.com/codex/tasks/task_e_6898db8ce25c83328502c493e7cc7f87